### PR TITLE
handle case of no config table passed to setup

### DIFF
--- a/lua/recorder.lua
+++ b/lua/recorder.lua
@@ -194,6 +194,7 @@ end
 ---Setup Macro Plugin
 ---@param config configObj
 function M.setup(config)
+	config = config or {}
 	slotIndex = 1 -- initial starting slot
 	macroRegs = config.slots or { "a", "b" }
 	logLevel = config.logLevel or vim.log.levels.INFO


### PR DESCRIPTION
Fixes #5 

If no `config` table is passed to the `setup()` function, defaults to empty table 