### PR TITLE
Fix using keys such as `<F4>` to record macros 

### DIFF
--- a/lua/recorder.lua
+++ b/lua/recorder.lua
@@ -50,7 +50,7 @@ local function toggleRecording()
 	-- NOTE the macro key records itself, so it has to be removed from the
 	-- register. As this function has to know the variable length of the
 	-- LHS key that triggered it, it has to be passed in via .setup()-function
-	local decodedToggleKey = fn.keytrans(toggleKey)
+	local decodedToggleKey = vim.api.nvim_replace_termcodes(toggleKey, true, true, true)
 	local recording = getMacro(reg):sub(1, -1 * (#decodedToggleKey + 1))
 	setMacro(reg, recording)
 

--- a/lua/recorder.lua
+++ b/lua/recorder.lua
@@ -100,10 +100,10 @@ local function playRecording()
 	end
 
 	local hasBreakPoints = macro:find(vim.pesc(breakPointKey))
-	local useLazyRedraw = v.count >= perf.threshold
+	local useLazyRedraw = v.count >= perf.countThreshold
 		and perf.lazyredraw
 		and not (opt.lazyredraw:get() == true)
-	local noSystemClipboard = v.count >= perf.threshold
+	local noSystemClipboard = v.count >= perf.countThreshold
 		and perf.noSystemclipboard
 		and (opt.clipboard:get() ~= "")
 


### PR DESCRIPTION
This fixes using `<F->` keys for recording macros. By using `vim.api.nvim_replace_termcodes` to escape they keys instead of keytrans.

 [#8](https://github.com/chrisgrieser/nvim-recorder/issues/8)

There is also a commit that fix the playing the macro, as it was crashing because perf.treshold was `nil` I assumed it was `perf.countTreshold` from the config.

You can however fix it in another commit if you prefer.
