### PR TITLE
fix: specify charwise mode when calling `vim.fn.setreg()`

### DIFF
--- a/lua/recorder.lua
+++ b/lua/recorder.lua
@@ -11,7 +11,7 @@ local macroRegs, slotIndex, logLevel, breakCounter
 -- Use this function to normalize keycodes (which can have multiple
 -- representations, e.g. <C-f> or <C-F>).
 ---@param mapping string
-local normalizeKeycodes = function (mapping)
+local normalizeKeycodes = function(mapping)
 	return fn.keytrans(vim.api.nvim_replace_termcodes(mapping, true, true, true))
 end
 
@@ -22,7 +22,7 @@ local getMacro = function(reg)
 	-- they are always consistent.
 	return vim.api.nvim_replace_termcodes(fn.keytrans(vim.fn.getreg(reg)), true, true, true)
 end
-local setMacro = vim.fn.setreg
+local setMacro = function(reg, recording) vim.fn.setreg(reg, recording, "c") end
 
 -- vars which can be set by the user
 local toggleKey, breakPointKey, dapSharedKeymaps, lessNotifications, useNerdfontIcons


### PR DESCRIPTION
From the docs for `setreg`:
```
If {options} contains no register settings, then the default
is to use character mode unless {value} ends in a <NL> for
string {value} and linewise mode for list {value}. Blockwise
mode is never selected automatically.
Returns zero for success, non-zero for failure.
```
The particular issue I noticed was that with any recording ending with `<CR>`, a `<NL>` was added, which resulted in unexpected behavior on playback.

## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  README.md (the `.txt` file is auto-generated and does not need to be modified).
- [x] Used conventional commits keywords.
