### PR TITLE
feat: add dynamic-slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ require("recorder").setup {
     -- specify one of options: 
     -- [static]   -> use static slots, this is default behaviour
     -- [rotate]   -> rotates through letters specified in slots[]
-    dynamicSlots = "rotate",
+    dynamicSlots = "static",
 
 	mapping = {
 		startStopRecording = "q",

--- a/README.md
+++ b/README.md
@@ -71,9 +71,8 @@ require("recorder").setup {
 	-- startup.
 	slots = { "a", "b" },
 
-    -- specify one of 3 options: 
+    -- specify one of options: 
     -- [static]   -> use static slots, this is default behaviour
-    -- [original] -> works as original neovim recording impl
     -- [rotate]   -> rotates through letters specified in slots[]
     dynamicSlots = "rotate",
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ require("recorder").setup {
 	-- startup.
 	slots = { "a", "b" },
 
+    -- specify one of 3 options: 
+    -- [static]   -> use static slots, this is default behaviour
+    -- [original] -> works as original neovim recording impl
+    -- [rotate]   -> rotates through letters specified in slots[]
+    dynamicSlots = "rotate",
+
 	mapping = {
 		startStopRecording = "q",
 		playMacro = "Q",

--- a/lua/recorder.lua
+++ b/lua/recorder.lua
@@ -62,6 +62,13 @@ local function toggleRecording()
 		if not isRecording() then
 			breakCounter = 0 -- reset break points
 			reg = fn.nr2char(fn.getchar())
+			if
+				string.match('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"', reg)
+				== nil
+			then
+				notify("Invalid reg [" .. reg .. "], aborting…", "essential")
+				return
+			end
 			normal("q" .. reg)
 
 			local isDefined = false

--- a/lua/recorder.lua
+++ b/lua/recorder.lua
@@ -83,6 +83,7 @@ local function toggleRecording()
 			notify("Recording to [" .. reg .. "]…", "essential")
 			return
 		end
+		reg = macroRegs[slotIndex]
 	else
 		if config.dynamicSlots == "rotate" and not isRecording() then
 			slotIndex = slotIndex + 1


### PR DESCRIPTION
new config option dynamicSlots can have 3 states:
1. disabled -> use static slots, default behaviour
2. original -> works as original neovim recording impl
3. rotate   -> goes through letters [a-z], if end is encountered it goes(overwrites) from start(a...)

I'm now reading I didn't need to edit `.txt`, oops. I tried implementing multiple features in single file I hope they will work after splitting. Sorry for formatting seems like `lua_ls` behaves differently than stylua.

