### PR TITLE
fix: Fix macro edit

### DIFF
--- a/lua/recorder.lua
+++ b/lua/recorder.lua
@@ -22,7 +22,7 @@ local getMacro = function(reg)
 	-- they are always consistent.
 	return vim.api.nvim_replace_termcodes(fn.keytrans(vim.fn.getreg(reg)), true, true, true)
 end
-local setMacro = function(reg, recording) vim.fn.setreg(reg, recording, "c") end
+local setMacro = function(reg, recording) vim.fn.setreg(reg, vim.api.nvim_replace_termcodes(recording, true, true, true), "c") end
 
 -- vars which can be set by the user
 local toggleKey, breakPointKey, dapSharedKeymaps, lessNotifications, useNerdfontIcons
@@ -214,7 +214,7 @@ end
 local function editMacro()
 	breakCounter = 0 -- reset breakpoint counter
 	local reg = macroRegs[slotIndex]
-	local macroContent = getMacro(reg)
+	local macroContent = fn.keytrans(getMacro(reg))
 	local inputConfig = {
 		prompt = "Edit Macro [" .. reg .. "]:",
 		default = macroContent,


### PR DESCRIPTION
When editing a macro, special keys are now displayed  with keycodes (e.g. <Esc>), and then they are incorporated back correctly in the register.

## What problem does this PR solve?

In normal use, editing a macro that contains special keys (e.g. <Esc>) will show them simply as blank spaces. If the macro is then saved unedited or with light editing by pressing <CR>, the special keys are not recovered, and the macro is broken. This makes macro editing a chore as the special keys have to be remembered and introduced again by inserting the literal character with i_CTRL-V or i_CTRL-Q.

## How does the PR solve it?

It modifies both the setMacro and the editMacro functions so special keys are shown as keycodes when the macro is being edited, and then transformed back into special keys when the macro is set. It also allows the use keycodes in the macro edition.

## Checklist
- [x] Used only `camelCase` variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be
  modified).
