### PR TITLE
feat: omit active register from macro edit prompt when only one register is used

### DIFF
--- a/lua/recorder.lua
+++ b/lua/recorder.lua
@@ -215,8 +215,12 @@ local function editMacro()
 	breakCounter = 0 -- reset breakpoint counter
 	local reg = macroRegs[slotIndex]
 	local macroContent = fn.keytrans(getMacro(reg))
+	local prompt = "Edit Macro [" .. reg .. "]:"
+	if (#macroRegs == 1) then
+		prompt = "Edit Macro:"
+	end
 	local inputConfig = {
-		prompt = "Edit Macro [" .. reg .. "]:",
+		prompt = prompt,
 		default = macroContent,
 	}
 	vim.ui.input(inputConfig, function(editedMacro)


### PR DESCRIPTION
## Problem statement
The prompt for editing macros is hard to customize.  
For a person like me, that likes to tailor their experience, this isn't ideal.
Use case: Streamline appearance by removing the active register from the prompt when using only one register.

## Proposed solution
Add a configuration option `editMacroPrompt` which is a function that formats the prompt.
The default value replicates previous behavior.
Modify `editPrompt` function to validate and use `editMacroPrompt`

## Checklist
- [x] Variable names follow `camelCase` convention.
- [x] The `README.md` has been updated for any new or modified functionality
  (the `.txt` file is auto-generated and does not need to be modified).

## Update
Modified the PR to only change the edit macro prompt from `Edit Macro [a]:` to `Edit Macro:` when using only one register.